### PR TITLE
FOGL-7012 unit tests fixes

### DIFF
--- a/tests/test_http_south.py
+++ b/tests/test_http_south.py
@@ -4,7 +4,6 @@
 # See: http://fledge-iot.readthedocs.io/
 # FLEDGE_END
 
-"""Unit test for fledge.plugins.south.http_south.http_south"""
 import copy
 import json
 from unittest import mock
@@ -15,16 +14,14 @@ from aiohttp.test_utils import make_mocked_request
 from aiohttp.streams import StreamReader
 from multidict import CIMultiDict
 from python.fledge.plugins.south.http_south import http_south
-from python.fledge.plugins.south.http_south.http_south import HttpSouthIngest, async_ingest, c_callback, c_ingest_ref, _DEFAULT_CONFIG as config
+from python.fledge.plugins.south.http_south.http_south import HttpSouthIngest, async_ingest, _DEFAULT_CONFIG as config
 
-__author__ = "Amarendra K Sinha"
-__copyright__ = "Copyright (c) 2017 Dianomic Systems"
+__author__ = "Amarendra K Sinha, Ashish Jabble"
+__copyright__ = "Copyright (c) 2017-2022 Dianomic Systems Inc."
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
-_CONFIG_CATEGORY_NAME = 'HTTP_SOUTH'
-_CONFIG_CATEGORY_DESCRIPTION = 'South Plugin HTTP Listener'
 _NEW_CONFIG = {
     'plugin': {
         'description': 'South Plugin HTTP Listener',
@@ -71,8 +68,6 @@ def mock_request(data, loop):
     return req
 
 
-@pytest.allure.feature("unit")
-@pytest.allure.story("plugin", "south", "http")
 def test_plugin_info():
     assert http_south.plugin_info() == {
         'name': 'HTTP South Listener',
@@ -84,8 +79,6 @@ def test_plugin_info():
     }
 
 
-@pytest.allure.feature("unit")
-@pytest.allure.story("plugin", "south", "http")
 def test_plugin_init():
     assert http_south.plugin_init(config) == config
 

--- a/tests/test_http_south.py
+++ b/tests/test_http_south.py
@@ -154,35 +154,6 @@ def test_plugin_reconfigure():
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("plugin", "south", "http")
-def test_plugin__stop(mocker, unused_port, loop):
-    # GIVEN
-    port = {
-        'description': 'Port to listen on',
-        'type': 'integer',
-        'default': str(unused_port()),
-    }
-    config_data = copy.deepcopy(config)
-    mocker.patch.dict(config_data, {'port': port})
-    config_data['port']['value'] = config_data['port']['default']
-    config_data['host']['value'] = config_data['host']['default']
-    config_data['uri']['value'] = config_data['uri']['default']
-    config_data['enableHttp']['value'] = config_data['enableHttp']['default']
-    log_exception = mocker.patch.object(http_south._LOGGER, "exception")
-    log_info = mocker.patch.object(http_south._LOGGER, "info")
-
-    # WHEN
-    http_south.plugin_start(config_data)
-    http_south._plugin_stop(config_data)
-
-    # THEN
-    assert 2 == log_info.call_count
-    calls = [call('Stopping South HTTP plugin.')]
-    log_info.assert_has_calls(calls, any_order=True)
-    assert 0 == log_exception.call_count
-
-
-@pytest.allure.feature("unit")
-@pytest.allure.story("plugin", "south", "http")
 def test_plugin_shutdown(mocker, unused_port):
     # GIVEN
     port = {

--- a/tests/test_http_south.py
+++ b/tests/test_http_south.py
@@ -152,38 +152,24 @@ def test_plugin_reconfigure():
     assert 1 == patch_shutdown.call_count
 
 
-@pytest.allure.feature("unit")
-@pytest.allure.story("plugin", "south", "http")
-def test_plugin_shutdown(mocker, unused_port):
+def test_plugin_shutdown():
     # GIVEN
-    port = {
-        'description': 'Port to listen on',
-        'type': 'integer',
-        'default': str(unused_port()),
-    }
     config_data = copy.deepcopy(config)
-    mocker.patch.dict(config_data, {'port': port})
     config_data['port']['value'] = config_data['port']['default']
     config_data['host']['value'] = config_data['host']['default']
     config_data['uri']['value'] = config_data['uri']['default']
     config_data['enableHttp']['value'] = config_data['enableHttp']['default']
-    log_exception = mocker.patch.object(http_south._LOGGER, "exception")
-    log_info = mocker.patch.object(http_south._LOGGER, "info")
-
-    # WHEN
-    http_south.plugin_start(config_data)
-    http_south.plugin_shutdown(config_data)
-
-    # THEN
-    assert 3 == log_info.call_count
-    calls = [call('Stopping South HTTP plugin.'),
-             call('South HTTP plugin shut down.')]
-    log_info.assert_has_calls(calls, any_order=True)
-    assert 0 == log_exception.call_count
+    config_data['enableCORS']['value'] = config_data['enableCORS']['default']
+    with patch.object(http_south._LOGGER, 'info') as patch_log_info:
+        # WHEN
+        http_south.plugin_start(config_data)
+        # THEN
+        http_south.plugin_shutdown(config_data)
+    assert 2 == patch_log_info.call_count
+    calls = [call('South HTTP plugin shut down.')]
+    patch_log_info.assert_has_calls(calls, any_order=True)
 
 
-@pytest.allure.feature("unit")
-@pytest.allure.story("plugin", "south", "http")
 @pytest.mark.skip(reason="server object is None in tests. To be investigated.")
 def test_plugin_shutdown_error(mocker, unused_port, loop):
     # GIVEN


### PR DESCRIPTION
```
collected 13 items                                                                                                                           

test_http_south.py::test_plugin_contract PASSED
test_http_south.py::test_plugin_info PASSED
test_http_south.py::test_plugin_init PASSED
test_http_south.py::test_plugin_start PASSED
test_http_south.py::test_plugin_start_exception PASSED
test_http_south.py::test_plugin_reconfigure PASSED
test_http_south.py::test_plugin_shutdown PASSED
test_http_south.py::test_plugin_shutdown_error[pyloop] SKIPPED
test_http_south.py::TestHttpSouthIngest::test_render_post_reading_ok[pyloop] PASSED
test_http_south.py::TestHttpSouthIngest::test_render_post_sensor_values_ok[pyloop] PASSED
test_http_south.py::TestHttpSouthIngest::test_render_post_invalid_payload[pyloop] PASSED
test_http_south.py::TestHttpSouthIngest::test_render_post_reading_missing_delimiter[pyloop] PASSED
test_http_south.py::TestHttpSouthIngest::test_render_post_reading_not_dict[pyloop] PASSED

============= 12 passed, 1 skipped in 0.66 seconds =======
```

Also Passed on CI - http://jenkins.dianomic.com:8080/view/Fledge%20PR%20tester/job/fledge-iot-plugins-tester/job/fledge-south-http/job/FOGL-7012/1/